### PR TITLE
Fix: correctly access record ID

### DIFF
--- a/lektor_atom.py
+++ b/lektor_atom.py
@@ -150,7 +150,7 @@ class AtomFeedBuilderProgram(BuildProgram):
                     author=item_author,
                     updated=get_item_updated(item, feed_source.item_date_field))
             except Exception as exc:
-                msg = '%s: %s' % (item.id, exc)
+                msg = '%s: %s' % (item['_id'], exc)
                 click.echo(click.style('E', fg='red') + ' ' + msg)
 
         with artifact.open('wb') as f:


### PR DESCRIPTION
As per the Lektor docs, field lookup outside of templates should use the
get-item operator. Additionally, the field is named “_id” rather than “id”.

Fixes #9